### PR TITLE
added possibility to generate wiremock stubs with regexp matching

### DIFF
--- a/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
@@ -39,11 +39,23 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 
 	private Map<String, Object> appendBody(ClientRequest clientRequest) {
 		Object body = clientRequest?.body?.clientValue
-		return body != null ? [bodyPatterns: [equalTo: parseBody(body)]] : [:]
+		if (body == null) {
+			return [:]
+		}
+		if (containsRegex(body)) {
+			return [bodyPatterns: [matches: parseBody(body)]]
+		}
+
+		return [bodyPatterns: [equalTo: parseBody(body)]]
 	}
 
-	private String parseBody(Object responseBodyObject) {
-		String responseBody = responseBodyObject as String
+	boolean containsRegex(Object bodyObject) {
+		String bodyString = bodyObject as String
+		return (bodyString =~ /\^.*\$/).find()
+	}
+
+	private String parseBody(Object bodyObject) {
+		String responseBody = bodyObject as String
 		try {
 			def json = new JsonSlurper().parseText(responseBody)
 			return escapeJava(JsonOutput.toJson(responseBody))


### PR DESCRIPTION
When pattern is used in DSL, resulting Wiremock stub is generated with this pattern used in 'bodyPattern.matches' section. Pattern is recognized only when used starting '^' and trailing '$'. 
Trying to partially solve this issue:
https://github.com/Codearte/accurest/issues/42
