### PR TITLE
Stub generation with regex fix + egualTo updated to equalToJson

### DIFF
--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
@@ -85,7 +85,7 @@ class DslToWiremockClientConverterSpec extends Specification {
 					"method":"PUT",
 					"url":"/api/12",
 					"bodyPatterns": [
-						{ "equalTo": "[{\\"created_at\\":\\"Sat Jul 26 09:38:57 +0000 2014\\",\\"id\\":492967299297845248,\\"id_str\\":\\"492967299297845248\\",\\"place\\":{\\"attributes\\":{},\\"bounding_box\\":{\\"coordinates\\":[[[-77.119759,38.791645],[-76.909393,38.791645],[-76.909393,38.995548],[-77.119759,38.995548]]],\\"type\\":\\"Polygon\\"},\\"country\\":\\"United States\\",\\"country_code\\":\\"US\\",\\"full_name\\":\\"Washington, DC\\",\\"id\\":\\"01fbe706f872cb32\\",\\"name\\":\\"Washington\\",\\"place_type\\":\\"city\\",\\"url\\":\\"http://api.twitter.com/1/geo/id/01fbe706f872cb32.json\\"},\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
+						{ "equalToJson": "[{\\"created_at\\":\\"Sat Jul 26 09:38:57 +0000 2014\\",\\"id\\":492967299297845248,\\"id_str\\":\\"492967299297845248\\",\\"place\\":{\\"attributes\\":{},\\"bounding_box\\":{\\"coordinates\\":[[[-77.119759,38.791645],[-76.909393,38.791645],[-76.909393,38.995548],[-77.119759,38.995548]]],\\"type\\":\\"Polygon\\"},\\"country\\":\\"United States\\",\\"country_code\\":\\"US\\",\\"full_name\\":\\"Washington, DC\\",\\"id\\":\\"01fbe706f872cb32\\",\\"name\\":\\"Washington\\",\\"place_type\\":\\"city\\",\\"url\\":\\"http://api.twitter.com/1/geo/id/01fbe706f872cb32.json\\"},\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
 					],
 					"headers": {
 						"Content-Type": {

--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
@@ -10,15 +10,15 @@ class DslToWiremockClientConverterSpec extends Specification {
 			def converter = new DslToWiremockClientConverter()
 		and:
 			String dslBody = """
-                io.codearte.accurest.dsl.GroovyDsl.make {
-                    request {
-                        method('PUT')
-                        url \$(client(~/\\/[0-9]{2}/), server('/12'))
-                    }
-                    response {
-                        status 200
-                    }
-                }
+				io.codearte.accurest.dsl.GroovyDsl.make {
+					request {
+						method('PUT')
+						url \$(client(~/\\/[0-9]{2}/), server('/12'))
+					}
+					response {
+						status 200
+					}
+				}
 """
 		when:
 			String json = converter.convertContent(dslBody)
@@ -33,7 +33,7 @@ class DslToWiremockClientConverterSpec extends Specification {
 			def converter = new DslToWiremockClientConverter()
 		and:
 			String dslBody = """
-                io.codearte.accurest.dsl.GroovyDsl.make {
+				io.codearte.accurest.dsl.GroovyDsl.make {
 					request {
 						method 'PUT'
 						url '/api/12'

--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WiremockToDslConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WiremockToDslConverterSpec.groovy
@@ -306,7 +306,7 @@ class WiremockToDslConverterSpec extends Specification {
 	"method": "POST",
 	"url": "/test",
 	"bodyPatterns": [{
-		"equalTo": "{\\"property1\\":\\"abc\\",\\"property2\\":\\"2017-01\\",\\"property3\\":\\"666\\",\\"property4\\":1428566412}"
+		"equalToJson": "{\\"property1\\":\\"abc\\",\\"property2\\":\\"2017-01\\",\\"property3\\":\\"666\\",\\"property4\\":1428566412}"
 	}]
   },
   "response": {
@@ -427,7 +427,7 @@ class WiremockToDslConverterSpec extends Specification {
 				"url" : "/test",
 				"method" : "POST",
 				"bodyPatterns" : [ {
-				  "equalTo" : "{\\"pan\\":\\"4855141150107894\\",\\"expirationDate\\":\\"2017-01\\",\\"dcvx\\":\\"178\\"}"
+				  "equalToJson" : "{\\"pan\\":\\"4855141150107894\\",\\"expirationDate\\":\\"2017-01\\",\\"dcvx\\":\\"178\\"}"
 				} ]
 			  },
 			  "response" : {

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/WiremockRequestStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/WiremockRequestStubStrategy.groovy
@@ -23,7 +23,7 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 
 	private Map<String, Object> buildRequestContent(ClientRequest request) {
 		return ([method    : request?.method?.clientValue,
-		        headers   : buildClientRequestHeadersSection(request.headers)
+				headers   : buildClientRequestHeadersSection(request.headers)
 		] << appendUrl(request) << appendBody(request)).findAll { it.value }
 	}
 
@@ -37,25 +37,25 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 		if (body == null) {
 			return [:]
 		}
-        if (clientRequest?.body?.containsPattern) {
-            return [bodyPatterns: parseMatchesBody(body)]
+		if (clientRequest?.body?.containsPattern) {
+			return [bodyPatterns: parseMatchesBody(body)]
 		}
 		return [bodyPatterns: [[equalToJson: parseBody(body)]]]
 	}
 
-    private def parseMatchesBody(def responseBodyObject) {
-        def regexList = new ArrayList<>()
-        responseBodyObject.each { k, v ->
-            if (v instanceof List) {
-                v.each {
-                    regexList.addAll(parseMatchesBody((Map<String, Object>)it))
-                }
-            } else {
-                String regex = ".*${k}\":.?\"${v}\".*"
-                regexList.add([matches: regex]);
-            }
-        }
-        return regexList
+	private def parseMatchesBody(def responseBodyObject) {
+		def regexList = new ArrayList<>()
+		responseBodyObject.each { k, v ->
+			if (v instanceof List) {
+				v.each {
+					regexList.addAll(parseMatchesBody((Map<String, Object>)it))
+				}
+			} else {
+				String regex = ".*${k}\":.?\"${v}\".*"
+				regexList.add([matches: regex]);
+			}
+		}
+		return regexList
 	}
 
 }

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Body.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Body.groovy
@@ -13,7 +13,7 @@ import java.util.regex.Pattern
 @EqualsAndHashCode(includeFields = true)
 class Body extends DslProperty {
 
-    boolean containsPattern
+	boolean containsPattern
 
 	private static final Pattern TEMPORARY_PATTERN_HOLDER = Pattern.compile('REGEXP>>(.*)<<')
 	private static final String JSON_VALUE_PATTERN_FOR_REGEX = 'REGEXP>>%s<<'
@@ -38,8 +38,8 @@ class Body extends DslProperty {
 
 	Body(GString bodyAsValue) {
 		super(extractValue(bodyAsValue, {it.clientValue}), extractValue(bodyAsValue, {it.serverValue}))
-        Object[] clientValues = getClientValues(bodyAsValue, {it.clientValue})
-        containsPattern = clientValues.find {it instanceof Pattern}
+		Object[] clientValues = getClientValues(bodyAsValue, {it.clientValue})
+		containsPattern = clientValues.find {it instanceof Pattern}
 	}
 
 	Body(DslProperty bodyAsValue) {
@@ -82,9 +82,9 @@ class Body extends DslProperty {
 			return value
 		})
 	}
-    
-    private static Object[] getClientValues(GString bodyAsValue, Closure valueProvider) {
-        bodyAsValue.values.collect { it instanceof DslProperty ? valueProvider(it) : it } as Object[]
-    }
+	
+	private static Object[] getClientValues(GString bodyAsValue, Closure valueProvider) {
+		bodyAsValue.values.collect { it instanceof DslProperty ? valueProvider(it) : it } as Object[]
+	}
 	
 }

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Body.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Body.groovy
@@ -13,6 +13,8 @@ import java.util.regex.Pattern
 @EqualsAndHashCode(includeFields = true)
 class Body extends DslProperty {
 
+    boolean containsPattern
+
 	private static final Pattern TEMPORARY_PATTERN_HOLDER = Pattern.compile('REGEXP>>(.*)<<')
 	private static final String JSON_VALUE_PATTERN_FOR_REGEX = 'REGEXP>>%s<<'
 
@@ -36,6 +38,8 @@ class Body extends DslProperty {
 
 	Body(GString bodyAsValue) {
 		super(extractValue(bodyAsValue, {it.clientValue}), extractValue(bodyAsValue, {it.serverValue}))
+        Object[] clientValues = getClientValues(bodyAsValue, {it.clientValue})
+        containsPattern = clientValues.find {it instanceof Pattern}
 	}
 
 	Body(DslProperty bodyAsValue) {
@@ -78,5 +82,9 @@ class Body extends DslProperty {
 			return value
 		})
 	}
-
+    
+    private static Object[] getClientValues(GString bodyAsValue, Closure valueProvider) {
+        bodyAsValue.values.collect { it instanceof DslProperty ? valueProvider(it) : it } as Object[]
+    }
+	
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -34,17 +34,17 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 		then:
 			new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
 {
-    "request": {
-        "method": "GET",
-        "urlPattern": "/[0-9]{2}"
-    },
-    "response": {
-        "status": 200,
-        "body": "{\\"id\\":\\"123\\",\\"surname\\":\\"Kowalsky\\",\\"name\\":\\"Jan\\",\\"created\\":\\"2014-02-02 12:23:43\\"}",
-        "headers": {
-            "Content-Type": "text/plain"
-        }
-    }
+	"request": {
+		"method": "GET",
+		"urlPattern": "/[0-9]{2}"
+	},
+	"response": {
+		"status": 200,
+		"body": "{\\"id\\":\\"123\\",\\"surname\\":\\"Kowalsky\\",\\"name\\":\\"Jan\\",\\"created\\":\\"2014-02-02 12:23:43\\"}",
+		"headers": {
+			"Content-Type": "text/plain"
+		}
+	}
 }
 ''')
 		and:
@@ -61,13 +61,13 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 				response {
 					status 200
 					body("""\
-                            {
-                                "id": "${value(client('123'), server('321'))}",
-                                "surname": "${value(client('Kowalsky'), server('Lewandowski'))}",
-                                "name": "Jan",
-                                "created" : "${$(client('2014-02-02 12:23:43'), server('2999-09-09 01:23:45'))}"
-                            }
-                        """
+							{
+								"id": "${value(client('123'), server('321'))}",
+								"surname": "${value(client('Kowalsky'), server('Lewandowski'))}",
+								"name": "Jan",
+								"created" : "${$(client('2014-02-02 12:23:43'), server('2999-09-09 01:23:45'))}"
+							}
+						"""
 					)
 					headers {
 						header 'Content-Type': 'text/plain'
@@ -79,17 +79,17 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 		then:
 			new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
 {
-    "request": {
-        "method": "GET",
-        "urlPattern": "/[0-9]{2}"
-    },
-    "response": {
-        "status": 200,
-        "body": "{\\"created\\":\\"2014-02-02 12:23:43\\",\\"id\\":\\"123\\",\\"name\\":\\"Jan\\",\\"surname\\":\\"Kowalsky\\"}",
-        "headers": {
-            "Content-Type": "text/plain"
-        }
-    }
+	"request": {
+		"method": "GET",
+		"urlPattern": "/[0-9]{2}"
+	},
+	"response": {
+		"status": 200,
+		"body": "{\\"created\\":\\"2014-02-02 12:23:43\\",\\"id\\":\\"123\\",\\"name\\":\\"Jan\\",\\"surname\\":\\"Kowalsky\\"}",
+		"headers": {
+			"Content-Type": "text/plain"
+		}
+	}
 }
 ''')
 		and:
@@ -111,10 +111,10 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 				response {
 					status 200
 					body("""\
-                            {
-                                "name": "Jan"
-                            }
-                        """
+							{
+								"name": "Jan"
+							}
+						"""
 					)
 					headers {
 						header 'Content-Type': 'text/plain'
@@ -126,22 +126,22 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 		then:
 			new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
 {
-    "request": {
-        "method": "GET",
-        "urlPattern": "/[0-9]{2}",
-        "bodyPatterns": [
-            {
-                "equalToJson":"{\\"name\\":\\"Jan\\"}"
-            }
-        ]
-    },
-    "response": {
-        "status": 200,
-        "body": "{\\"name\\":\\"Jan\\"}",
-        "headers": {
-            "Content-Type": "text/plain"
-        }
-    }
+	"request": {
+		"method": "GET",
+		"urlPattern": "/[0-9]{2}",
+		"bodyPatterns": [
+			{
+				"equalToJson":"{\\"name\\":\\"Jan\\"}"
+			}
+		]
+	},
+	"response": {
+		"status": 200,
+		"body": "{\\"name\\":\\"Jan\\"}",
+		"headers": {
+			"Content-Type": "text/plain"
+		}
+	}
 }
 ''')
 		and:
@@ -164,10 +164,10 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			response {
 				status 200
 				body("""\
-                            {
-                                "name": "Jan"
-                            }
-                     """
+							{
+								"name": "Jan"
+							}
+					 """
 				)
 				headers {
 					header 'Content-Type': 'text/plain'
@@ -178,23 +178,23 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			String wiremockStub = new WiremockStubStrategy(groovyDsl).toWiremockClientStub()
 		then:
 			new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
-            {
-                "request": {
-                    "method": "GET",
-                    "urlPattern": "/[0-9]{2}",
-                    "bodyPatterns": [
-                                    {"matches": ".*personalId\\":.?\\"[0-9]{11}\\".*"}
-                                    ]
-                },
-                "response": {
-                    "status": 200,
-                    "body": "{\\"name\\":\\"Jan\\"}",
-                    "headers": {
-                        "Content-Type": "text/plain"
-                    }
-                }
-            }
-            ''')
+			{
+				"request": {
+					"method": "GET",
+					"urlPattern": "/[0-9]{2}",
+					"bodyPatterns": [
+									{"matches": ".*personalId\\":.?\\"[0-9]{11}\\".*"}
+									]
+				},
+				"response": {
+					"status": 200,
+					"body": "{\\"name\\":\\"Jan\\"}",
+					"headers": {
+						"Content-Type": "text/plain"
+					}
+				}
+			}
+			''')
 		and:
 			stubMappingIsValidWiremockStub(wiremockStub)
 	}
@@ -209,10 +209,10 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			}
 		expect:
 			new WiremockRequestStubStrategy(groovyDsl).buildClientRequestContent() == new JsonSlurper().parseText('''
-    {
-        "method":"GET"
-    }
-    ''')
+	{
+		"method":"GET"
+	}
+	''')
 	}
 
 	def "should generate request when two elements are provided "() {
@@ -225,11 +225,11 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			}
 		expect:
 			new WiremockRequestStubStrategy(groovyDsl).buildClientRequestContent() == new JsonSlurper().parseText('''
-    {
-        "method":"GET",
-        "url":"/sth"
-    }
-    ''')
+	{
+		"method":"GET",
+		"url":"/sth"
+	}
+	''')
 	}
 
 	def "should generate request with urlPattern for client side"() {
@@ -244,10 +244,10 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			}
 		expect:
 			new WiremockRequestStubStrategy(groovyDsl).buildClientRequestContent() == new JsonSlurper().parseText('''
-    {
-        "urlPattern":"/^[0-9]{2}$"
-    }
-    ''')
+	{
+		"urlPattern":"/^[0-9]{2}$"
+	}
+	''')
 	}
 
 	def "should generate stub with some headers section for client side"() {
@@ -269,87 +269,87 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			}
 		expect:
 			new WiremockRequestStubStrategy(groovyDsl).buildClientRequestContent() == new JsonSlurper().parseText('''
-    {
-        "headers": {
-            "Content-Type": {
-                "equalTo": "text/xml"
-            },
-            "Accept": {
-                "matches": "text/.*"
-            },
-            "X-Custom-Header": {
-                "matches": "^.*2134.*$"
-            }
-        }
-    }
-    ''')
+	{
+		"headers": {
+			"Content-Type": {
+				"equalTo": "text/xml"
+			},
+			"Accept": {
+				"matches": "text/.*"
+			},
+			"X-Custom-Header": {
+				"matches": "^.*2134.*$"
+			}
+		}
+	}
+	''')
 	}
 
-    def 'should convert groovy dsl stub with rich tree Body as String to wiremock stub for the client side'() {
-        given:
-        GroovyDsl groovyDsl = GroovyDsl.make {
-            request {
-                method('GET')
-                url $(client(~/\/[0-9]{2}/), server('/12'))
-                body """\
-                    {
-                      "personalId": "${value(client(regex('[0-9]{11}')), server('57593728525'))}",
-                      "firstName": "${value(client(regex('.*')), server('ალეკო'))}",
-                      "lastName": "${value(client(regex('.*')), server('ბზარაშვილი'))}",
-                      "birthDate": "${value(client(regex('[0-9]{4}-[0-9]{2}-[0-9]{2}')), server('1985-12-12'))}",
-                      "errors": [
-                                {
-                                  "propertyName": "${value(client(regex('[0-9]{2}')), server('04'))}",
-                                  "providerValue": "Test"
-                                },
-                                {
-                                  "propertyName": "${value(client(regex('[0-9]{2}')), server('08'))}",
-                                  "providerValue": "Test"
-                                }
-                              ]
-                    }
-                    """
-            }
-            response {
-                status 200
-                body("""\
-                            {
-                                "name": "Jan"
-                            }
-                        """
-                )
-                headers {
-                    header 'Content-Type': 'text/plain'
-                }
-            }
-        }
-        when:
-        String wiremockStub = new WiremockStubStrategy(groovyDsl).toWiremockClientStub()
-        then:
-        new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
-        {
-            "request": {
-                        "method": "GET",
-                        "urlPattern": "/[0-9]{2}",
-                        "bodyPatterns": [
-                                        {"matches": ".*birthDate\\":.?\\"[0-9]{4}-[0-9]{2}-[0-9]{2}\\".*"},
-                                        {"matches": ".*propertyName\\":.?\\"[0-9]{2}\\".*"},
-                                        {"matches": ".*providerValue\\":.?\\"Test\\".*"},
-                                        {"matches": ".*propertyName\\":.?\\"[0-9]{2}\\".*"},
-                                        {"matches": ".*providerValue\\":.?\\"Test\\".*"},
-                                        {"matches": ".*firstName\\":.?\\".*\\".*"},
-                                        {"matches": ".*lastName\\":.?\\".*\\".*"},
-                                        {"matches": ".*personalId\\":.?\\"[0-9]{11}\\".*"}
-                                        ]
-                        },
-            "response": {
-                        "status": 200,
-                        "body": "{\\"name\\":\\"Jan\\"}",
-                        "headers": {
-                                    "Content-Type": "text/plain"
-                                    }
-                        }
-        }
-        ''')
-    }
+	def 'should convert groovy dsl stub with rich tree Body as String to wiremock stub for the client side'() {
+		given:
+		GroovyDsl groovyDsl = GroovyDsl.make {
+			request {
+				method('GET')
+				url $(client(~/\/[0-9]{2}/), server('/12'))
+				body """\
+					{
+					  "personalId": "${value(client(regex('[0-9]{11}')), server('57593728525'))}",
+					  "firstName": "${value(client(regex('.*')), server('Bruce'))}",
+					  "lastName": "${value(client(regex('.*')), server('Lee'))}",
+					  "birthDate": "${value(client(regex('[0-9]{4}-[0-9]{2}-[0-9]{2}')), server('1985-12-12'))}",
+					  "errors": [
+								{
+								  "propertyName": "${value(client(regex('[0-9]{2}')), server('04'))}",
+								  "providerValue": "Test"
+								},
+								{
+								  "propertyName": "${value(client(regex('[0-9]{2}')), server('08'))}",
+								  "providerValue": "Test"
+								}
+							  ]
+					}
+					"""
+			}
+			response {
+				status 200
+				body("""\
+							{
+								"name": "Jan"
+							}
+						"""
+				)
+				headers {
+					header 'Content-Type': 'text/plain'
+				}
+			}
+		}
+		when:
+		String wiremockStub = new WiremockStubStrategy(groovyDsl).toWiremockClientStub()
+		then:
+		new JsonSlurper().parseText(wiremockStub) == new JsonSlurper().parseText('''
+		{
+			"request": {
+						"method": "GET",
+						"urlPattern": "/[0-9]{2}",
+						"bodyPatterns": [
+										{"matches": ".*birthDate\\":.?\\"[0-9]{4}-[0-9]{2}-[0-9]{2}\\".*"},
+										{"matches": ".*propertyName\\":.?\\"[0-9]{2}\\".*"},
+										{"matches": ".*providerValue\\":.?\\"Test\\".*"},
+										{"matches": ".*propertyName\\":.?\\"[0-9]{2}\\".*"},
+										{"matches": ".*providerValue\\":.?\\"Test\\".*"},
+										{"matches": ".*firstName\\":.?\\".*\\".*"},
+										{"matches": ".*lastName\\":.?\\".*\\".*"},
+										{"matches": ".*personalId\\":.?\\"[0-9]{11}\\".*"}
+										]
+						},
+			"response": {
+						"status": 200,
+						"body": "{\\"name\\":\\"Jan\\"}",
+						"headers": {
+									"Content-Type": "text/plain"
+									}
+						}
+		}
+		''')
+	}
 }

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
@@ -52,7 +52,7 @@ class BasicFunctionalSpec extends IntegrationSpec {
         },
         "url": "/api/12",
         "bodyPatterns": [
-            { "equalTo": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
+            { "equalToJson": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
         ]
     },
     "response": {

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
@@ -43,21 +43,21 @@ class BasicFunctionalSpec extends IntegrationSpec {
 			def generatedClientJsonStub = file(GENERATED_CLIENT_JSON_STUB).text
 			new JsonSlurper().parseText(generatedClientJsonStub) == new JsonSlurper().parseText("""
 {
-    "request": {
-        "method": "PUT",
-        "headers": {
-            "Content-Type": {
-                "equalTo": "application/json"
-            }
-        },
-        "url": "/api/12",
-        "bodyPatterns": [
-            { "equalToJson": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
-        ]
-    },
-    "response": {
-        "status": 200
-    }
+	"request": {
+		"method": "PUT",
+		"headers": {
+			"Content-Type": {
+				"equalTo": "application/json"
+			}
+		},
+		"url": "/api/12",
+		"bodyPatterns": [
+			{ "equalToJson": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
+		]
+	},
+	"response": {
+		"status": 200
+	}
 }
 """)
 	}


### PR DESCRIPTION
Fixed generation stubs from regex values - now it took all regex and generate matchers in stubs. 

Whit equalTo bodyPattern have to be the same like defined pattern, with equalToJson, there can be whitespaces, param in another position in JSON, so equalToJson is correct solution (from wiremock documentation as well).
